### PR TITLE
Simplify coding for deprecated multiple issues coding

### DIFF
--- a/WikiFunctions/WikiRegexes.cs
+++ b/WikiFunctions/WikiRegexes.cs
@@ -254,8 +254,8 @@ namespace WikiFunctions
                     DateYearMonthParameter = @"date={{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}";
                     Orphan = Tools.NestedTemplateRegex(new[] {@"Orphan"});
                //     uncattemplate = UncatTemplatesEN;
-                    DeadEnd = new Regex(@"(?:{{\s*(?:[Dd]ead ?end|[Ii]nternal ?links|[Nn]uevointernallinks|[Dd]ep)(?:\|(?:[^{}]+|" +DateYearMonthParameter +@"))?}}|({{\s*(?:[Aa]rticle|[Mm]ultiple)\s*issues\b[^{}]*?(?:{{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}})?[^{}]*?)*\|\s*dead ?end\s*=\s*(?:{{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}|[^{}\|]+))");
-                    Wikify = new Regex(@"(?:{{\s*(?:Wikify|Underlinked)(?:\s*\|\s*(?:" +DateYearMonthParameter +@"|.*?))?}}|({{\s*(?:Article|Multiple)\s*issues\b[^{}]*?)\|\s*(?:wikify|underlinked)\s*=\s*(?:{{subst:CURRENTMONTHNAME}} {{subst:CURRENTYEAR}}|[^{}\|]+))", RegexOptions.IgnoreCase);
+			        DeadEnd = Tools.NestedTemplateRegex(new[] {@"DeadEnd"});
+					Wikify = Tools.NestedTemplateRegex(new[] {@"Wikify"});
                     InUse = Tools.NestedTemplateRegex(new[] {"Inuse", "In use", "GOCEinuse", "goceinuse", "in creation", "increation" });
                     LinkFGAs =  Tools.NestedTemplateRegex(new [] {"link FA", "link GA"});
                //     DisambigString = DisambigTemplatesEN;


### PR DESCRIPTION
Now that the multiple issues templates have been standardized, there is no need for the alternate template redirect cases