### PR TITLE
Add parameters for WPMilhist if applicable

### DIFF
--- a/WikiFunctions/TalkPageFixes.cs
+++ b/WikiFunctions/TalkPageFixes.cs
@@ -566,15 +566,15 @@ namespace WikiFunctions.TalkPages
                 {
                     newvalue = Tools.SetTemplateParameterValue(newvalue, "military-work-group", "yes");
                     articletext = articletext.Replace(m.Value, newvalue);
-				}
+		}
 				
-		    // If {{WPMilhist}} then add military-priority= to WPbiography
+	    // If {{WPMilhist}} then add military-priority= to WPbiography
                 Match military-priority = WPMilhistR.Match(articletext);
                 if (military-priority.Success)
                 {
                     newvalue = Tools.SetTemplateParameterValue(newvalue, "military-priority", "");
                     articletext = articletext.Replace(m.Value, newvalue);
-				}
+		}
             
             // move above any other WikiProject
             if (!WikiRegexes.WikiProjectBannerShellTemplate.IsMatch(articletext))

--- a/WikiFunctions/TalkPageFixes.cs
+++ b/WikiFunctions/TalkPageFixes.cs
@@ -560,6 +560,22 @@ namespace WikiFunctions.TalkPages
             // remove {{activepol}} if {{WPBiography|activepol=yes}}
             articletext = ActivepolRegex.Replace(articletext, "");
             
+            // If {{WPMilhist}} then add military-work-group=yes to WPbiography
+                Match military-work-group = WPMilhistR.Match(articletext);
+                if (military-work-group.Success)
+                {
+                    newvalue = Tools.SetTemplateParameterValue(newvalue, "military-work-group", "yes");
+                    articletext = articletext.Replace(m.Value, newvalue);
+				}
+				
+		    // If {{WPMilhist}} then add military-priority= to WPbiography
+                Match military-priority = WPMilhistR.Match(articletext);
+                if (military-priority.Success)
+                {
+                    newvalue = Tools.SetTemplateParameterValue(newvalue, "military-priority", "");
+                    articletext = articletext.Replace(m.Value, newvalue);
+				}
+            
             // move above any other WikiProject
             if (!WikiRegexes.WikiProjectBannerShellTemplate.IsMatch(articletext))
             {


### PR DESCRIPTION
Add | military-work-group = and | military-priority = to WPBiography if WPMilhist is present and doesn't already have it