### PR TITLE
Change two criteria of tagging in ARwiki

### DIFF
--- a/WikiFunctions/Parse/Tagger.cs
+++ b/WikiFunctions/Parse/Tagger.cs
@@ -219,7 +219,7 @@ namespace WikiFunctions.Parse
                 }
             }
 
-            if (length <= 300 && !WikiRegexes.Stub.IsMatch(commentsCategoriesStripped) &&
+            if (((Variables.LangCode.Equals("ar") && words <=300) ||(length <= 300)) && !WikiRegexes.Stub.IsMatch(commentsCategoriesStripped) &&
                 !WikiRegexes.Disambigs.IsMatch(commentsCategoriesStripped) && !WikiRegexes.SIAs.IsMatch(commentsCategoriesStripped) && !WikiRegexes.NonDeadEndPageTemplates.IsMatch(commentsCategoriesStripped))
             {
                 // add stub tag. Exclude pages their title starts with "List of..."

--- a/WikiFunctions/Parse/Tagger.cs
+++ b/WikiFunctions/Parse/Tagger.cs
@@ -693,6 +693,7 @@ namespace WikiFunctions.Parse
                     !name.StartsWith("Proposed deletion") &&
                     !name.Contains("proposed for deletion") &&
                     !name.Contains("proposed deletions") &&
+                    (Variables.LangCode.Equals("ar") ? a.Exists.Equals ("Yes") : true) &&
                     !name.Equals("Articles created via the Article Wizard")
                 select a).ToList();
         }


### PR DESCRIPTION
Hi.

Please approve the edits I made to the tagging process in Arwiki. I've made two things:

- Change the criteria of tagging with {{Stub}} to be (less than or equal 300 **_words_**).

- Change the criteria of tagging with {{Uncategorized}} to be (**_Exclude red categories_** from the total count).

These edits are approved by arwiki community. You can see the discussion in [this link](https://ar.wikipedia.org/wiki/%D9%88%D9%8A%D9%83%D9%8A%D8%A8%D9%8A%D8%AF%D9%8A%D8%A7:%D8%A7%D9%84%D9%85%D9%8A%D8%AF%D8%A7%D9%86/%D8%AA%D9%82%D9%86%D9%8A%D8%A9#%D8%AA%D8%AD%D8%AF%D9%8A%D8%AB_%D8%A8%D9%88%D8%AA_%D8%A7%D9%84%D8%B5%D9%8A%D8%A7%D9%86%D8%A9).

If anything I can do to optimize these edits, please let me know.

Best.