### PR TITLE
Add qualifyers for fandom and Gamepedia

### DIFF
--- a/WikiFunctions/Tools.cs
+++ b/WikiFunctions/Tools.cs
@@ -106,7 +106,11 @@ namespace WikiFunctions
         /// </summary>
         public static bool IsWikimediaProject(ProjectEnum p)
         {
-            return (p != ProjectEnum.custom && p != ProjectEnum.wikia);
+            return (p != ProjectEnum.custom &&
+                    p != ProjectEnum.wikia &&
+                    p != ProjectEnum.fandom &&
+                    p != ProjectEnum.gamepedia &&
+                   );
         }
 
         private static readonly char[] InvalidChars = { '[', ']', '{', '}', '|', '<', '>', '#' };


### PR DESCRIPTION
Add qualifyers for fandom and Gamepedia so they won't be included as a Wikimedia project in Tool tests