### PR TITLE
Expand functionality for General fixes and talk page fixes

### DIFF
--- a/WikiFunctions/Article/Article.cs
+++ b/WikiFunctions/Article/Article.cs
@@ -377,7 +377,8 @@ namespace WikiFunctions
         { get { return mAWBLogListener.Skipped; } }
 
         /// <summary>
-        /// Returns true of article general fixes can be applied to the page: article, draft or category namespace, sandbox, template documnetation page or Anexo namespace on es-wiki and pt-wiki
+        /// Returns true of article general fixes can be applied to the page: article, draft or category namespace, sandbox.
+        /// template documenetation page or Anexo namespace on es-wiki and pt-wiki
         /// </summary>
         [XmlIgnore]
         public bool CanDoGeneralFixes

--- a/WikiFunctions/Article/Article.cs
+++ b/WikiFunctions/Article/Article.cs
@@ -405,7 +405,12 @@ namespace WikiFunctions
             {
                 return (NameSpaceKey == Namespace.Talk
                         || NameSpaceKey == Namespace.BookTalk
-                        || NameSpaceKey == Namespace.CategoryTalk);
+                        || NameSpaceKey == Namespace.CategoryTalk
+                        || NameSpaceKey == Namespace.DraftTalk
+                        || NameSpaceKey == Namespace.FileTalk
+                        || NameSpaceKey == Namespace.PortalTalk
+                        || NameSpaceKey == Namespace.TemplateTalk
+                        || NameSpaceKey == Namespace.WikipediaTalk);
             }
         }
 

--- a/WikiFunctions/Article/Article.cs
+++ b/WikiFunctions/Article/Article.cs
@@ -377,7 +377,7 @@ namespace WikiFunctions
         { get { return mAWBLogListener.Skipped; } }
 
         /// <summary>
-        /// Returns true of article general fixes can be applied to the page: article or category namespace, sandbox, template documnetation page or Anexo namespace on es-wiki and pt-wiki
+        /// Returns true of article general fixes can be applied to the page: article, draft or category namespace, sandbox, template documnetation page or Anexo namespace on es-wiki and pt-wiki
         /// </summary>
         [XmlIgnore]
         public bool CanDoGeneralFixes
@@ -385,6 +385,7 @@ namespace WikiFunctions
             get
             {
                 return (NameSpaceKey == Namespace.Article
+                        || NameSpaceKey == Namespace.Draft
                         || NameSpaceKey == Namespace.Category
                         || Name.Contains("Sandbox")
                         || Name.Contains("sandbox")


### PR DESCRIPTION
T118074 Seems to have support for extending the WikiProject talk page fixes to other namespaces. Might need some testing and refinement though.