### PR TITLE
replace Wikia.com with Wikia.org

### DIFF
--- a/WikiFunctions/Variables.cs
+++ b/WikiFunctions/Variables.cs
@@ -675,7 +675,7 @@ namespace WikiFunctions
                     LangCode = "en";
                     break;
                 case ProjectEnum.wikia:
-                    URL = "https://" + customProject + ".wikia.com";
+                    URL = "https://" + customProject + ".wikia.org";
                     URLEnd = "/";
                     break;
 		case ProjectEnum.fandom:


### PR DESCRIPTION
With the change from Wikia to Fandom some projects were left under Wikia and the domain was changed to .org.