### PR TITLE
Update URL for checkwiki

### DIFF
--- a/WikiFunctions/Lists/Providers/NonMWListProviders.cs
+++ b/WikiFunctions/Lists/Providers/NonMWListProviders.cs
@@ -129,7 +129,7 @@ namespace WikiFunctions.Lists.Providers
 
             foreach (string errornumber in searchCriteria)
             {
-                string title = "https://tools.wmflabs.org/checkwiki/cgi-bin/checkwiki.cgi?project=" + Variables.LangCode +
+                string title = "https://checkwiki.toolforge.org/cgi-bin/checkwiki.cgi?project=" + Variables.LangCode +
                                "wiki&view=bots&id=" + errornumber + "&offset=0";
                 list.AddRange(base.MakeList(title));
             }


### PR DESCRIPTION
Now using toolforge subdomains rather than directories, so the new URL is https://checkwiki.toolforge.org/cgi-bin/checkwiki.cgi. The endpoint is unchanged - if you [take a look at the URL itself (sample)](https://checkwiki.toolforge.org/cgi-bin/checkwiki.cgi?project=enwiki&view=bots&id=1&offset=0) you can see the output is identical.