### PR TITLE
Change one criteria of tagging in ARwiki

### DIFF
--- a/WikiFunctions/Parse/Tagger.cs
+++ b/WikiFunctions/Parse/Tagger.cs
@@ -227,8 +227,11 @@ namespace WikiFunctions.Parse
                 {
                     if (Variables.LangCode.Equals("ar"))
                     {
-                        articleText += Tools.Newline("{{بذرة}}", 3);
-                        tagsAdded.Add("بذرة");
+                        if (!WikiRegexes.StubTWO.IsMatch(commentsCategoriesStripped))
+                        {
+                            articleText += Tools.Newline("{{بذرة}}", 3);
+                            tagsAdded.Add("بذرة");
+                        }
                     }
                     else if (Variables.LangCode.Equals("arz"))
                     {

--- a/WikiFunctions/WikiRegexes.cs
+++ b/WikiFunctions/WikiRegexes.cs
@@ -159,6 +159,7 @@ namespace WikiFunctions
                     Wikify =Tools.NestedTemplateRegex(@"وصلات قليلة");
                     InUse = Tools.NestedTemplateRegex(new[] {"إنشاء", "تحرر", "Underconstruction", "تحت الإنشاء", "تحت الأنشاء", "يحرر", "إنشاء مقالة", "انشاء مقالة", "Inuse", "تحرير كثيف", "يحرر المقالة", "تحت التحرير", "قيد الاستخدام" });
                     DisambigString = "([Dd]isambig|توضيح|صفحة توضيح|أسمياء)";
+                    StubTWO = Tools.NestedTemplateRegex(@"الاسم الشائع للحيوان");
                     break;
                 case "arz":
                     Orphan = Tools.NestedTemplateRegex(@"يتيمه");


### PR DESCRIPTION
Hello!
Please approve the edit I made:

Requests from ARwiki https://ar.wikipedia.org/w/index.php?oldid=52133204. If this template "الاسم الشائع للحيوان" in text, do not add stub tag.

Thanks.