### PR TITLE
Create a basic GitHub Actions workflow

### DIFF
--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -1,0 +1,25 @@
+name: awb
+
+on: [push, pull_request]
+
+jobs:
+  build-windows:
+    name: Windows
+    runs-on: ${{ matrix.windows-version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        windows-version: ['windows-latest', 'windows-2016']
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v1.0.2
+      - name: Build
+        run: |
+            MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.windows-version }}
+          path: AWB/bin/Release


### PR DESCRIPTION
This commit creates a simple GitHub Actions workflow to automatically build the `AutoWikiBrowser no plugins.sln` solution file on commits and PRs.

Additionally, this workflow will automatically upload the results of the build as artifacts, which are ZIP files with the contents of `AWB/bin/Release` so that they can be tested locally.

Currently, these build using MSBuild on both Windows Server 2016 and Windows Server 2019.

Further testing can be performed on the runners if needed. Building of plugins should be trivial to add.