### PR TITLE
fix: increase contrast for username in stats bar

### DIFF
--- a/AWB/Main.cs
+++ b/AWB/Main.cs
@@ -2348,6 +2348,7 @@ font-size: 150%;'>No changes</h2><p>Press the ""Skip"" button below to skip to t
             if (TheSession.Status == WikiStatusResult.Registered)
             {
                 lblUserName.BackColor = Color.Green;
+                lblUserName.ForeColor = Color.White;
                 btnStart.Enabled = true;
             }
             else


### PR DESCRIPTION
Currently, the username is black on a dark green background, which doesn't really contrast well. With this change, the text is now white.

For reference, here's the current text:
![image](https://user-images.githubusercontent.com/42586271/125839711-0670343d-09cf-44ec-9b66-e741103c3869.png)

compared to the new text:
![image](https://user-images.githubusercontent.com/42586271/125840018-2b6540ec-0fe1-439a-b8b3-85925756a90d.png)