### PR TITLE
Fix broken URL in Regex Tester

### DIFF
--- a/WikiFunctions/Controls/RegexTester.cs
+++ b/WikiFunctions/Controls/RegexTester.cs
@@ -281,7 +281,7 @@ namespace WikiFunctions.Controls
 
         private static void RegexTesterHelpRequested()
         {
-            Tools.OpenURLInBrowser("http://msdn2.microsoft.com/en-us/library/az24scfc.aspx");
+            Tools.OpenURLInBrowser("https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference");
         }
 
         private void RegexTester_FormClosing(object sender, FormClosingEventArgs e)


### PR DESCRIPTION
This PR fixes a broken URL in the Regex Tester help button.

Reported on Phabricator [here](https://phabricator.wikimedia.org/T329002).

Rather than choosing the archived link provided by Qwerty284651, I have chosen the new canonical link for Microsoft's same documentation page.