### PR TITLE
Update the GitHub Actions workflow

### DIFF
--- a/.github/workflows/awb.yml
+++ b/.github/workflows/awb.yml
@@ -9,17 +9,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        windows-version: ['windows-latest', 'windows-2016']
+        windows-version: ['windows-2019']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.3.1
       - name: Build
         run: |
             MSBuild.exe $Env:GITHUB_WORKSPACE\'AutoWikiBrowser no plugins.sln' /p:Configuration=Release
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.2
         with:
           name: ${{ matrix.windows-version }}
           path: AWB/bin/Release


### PR DESCRIPTION
This PR will update the GitHub Actions workflow. It simply forces us to run on Windows 2019, and updates some of the actions to their latest versions to eliminate deprecation warnings.