### PR TITLE
Use .NET Framework 4.8

### DIFF
--- a/AWB/AutoWikiBrowser.csproj
+++ b/AWB/AutoWikiBrowser.csproj
@@ -23,7 +23,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <StartupObject>AutoWikiBrowser.Program</StartupObject>
     <TargetFrameworkProfile />
     <PublishUrl>D:\My Webs\</PublishUrl>

--- a/AWB/app.config
+++ b/AWB/app.config
@@ -27,4 +27,4 @@
             </setting>
         </AutoWikiBrowser.Properties.Settings>
     </userSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/AWBUpdater/AWBUpdater.csproj
+++ b/AWBUpdater/AWBUpdater.csproj
@@ -16,7 +16,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <StartupObject>AWBUpdater.Program</StartupObject>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/AWBUpdater/app.config
+++ b/AWBUpdater/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Extras/AWBPackager/AWBPackager.csproj
+++ b/Extras/AWBPackager/AWBPackager.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Extras/AWBPackager/app.config
+++ b/Extras/AWBPackager/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Extras/CheckPage Converter/CheckPage Converter.csproj
+++ b/Extras/CheckPage Converter/CheckPage Converter.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>CheckPage_Converter</RootNamespace>
     <AssemblyName>CheckPage Converter</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Extras/CheckPage Converter/app.config
+++ b/Extras/CheckPage Converter/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Extras/DBScanner/DBScanner.csproj
+++ b/Extras/DBScanner/DBScanner.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Extras/DBScanner/app.config
+++ b/Extras/DBScanner/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Extras/Regex Tester/Regex Tester.csproj
+++ b/Extras/Regex Tester/Regex Tester.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Extras/Regex Tester/app.config
+++ b/Extras/Regex Tester/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Extras/Sandbox/App.config
+++ b/Extras/Sandbox/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/Extras/Sandbox/Sandbox.csproj
+++ b/Extras/Sandbox/Sandbox.csproj
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>Sandbox</RootNamespace>
     <AssemblyName>Sandbox</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/Plugins/BingSearch/BingSearch.csproj
+++ b/Plugins/BingSearch/BingSearch.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WikiFunctions.Plugins.ListMaker.BingSearch</RootNamespace>
     <AssemblyName>BingSearchPlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Plugins/CFD/CFD.csproj
+++ b/Plugins/CFD/CFD.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Plugins/Delinker/DelinkerPlugin.csproj
+++ b/Plugins/Delinker/DelinkerPlugin.csproj
@@ -16,7 +16,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Plugins/Fronds/Fronds.csproj
+++ b/Plugins/Fronds/Fronds.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Fronds</RootNamespace>
     <AssemblyName>Fronds</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Plugins/Fronds/app.config
+++ b/Plugins/Fronds/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/></startup></configuration>
+	<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/Plugins/IFD/IFD.csproj
+++ b/Plugins/IFD/IFD.csproj
@@ -15,7 +15,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Plugins/Kingbotk Plugin/Kingbotk Plugin.csproj
+++ b/Plugins/Kingbotk Plugin/Kingbotk Plugin.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoWikiBrowser.Plugins.Kingbotk</RootNamespace>
     <AssemblyName>Kingbotk AWB Plugin</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Plugins/NoLimitsPlugin/NoLimitsPlugin.csproj
+++ b/Plugins/NoLimitsPlugin/NoLimitsPlugin.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WikiFunctions.Plugins.ListMaker.NoLimitsPlugin</RootNamespace>
     <AssemblyName>NoLimitsPlugin</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Plugins/TheTemplator/TheTemplator.csproj
+++ b/Plugins/TheTemplator/TheTemplator.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoWikiBrowser.Plugins.TheTemplator</RootNamespace>
     <AssemblyName>TheTemplator</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/Plugins/TypoScan/TypoScan.csproj
+++ b/Plugins/TypoScan/TypoScan.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WikiFunctions.Plugins.ListMaker.TypoScan</RootNamespace>
     <AssemblyName>TypoScan</AssemblyName>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -17,7 +17,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/WikiFunctions/WikiFunctions.csproj
+++ b/WikiFunctions/WikiFunctions.csproj
@@ -13,7 +13,7 @@
     <OldToolsVersion>3.5</OldToolsVersion>
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
-    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
4.8 is the last version supported by Windows 7.
The code doesn't use any features specific to 4.8.1 so there's no technical reason to use that.