### PR TITLE
Print HRESULT for a WebException

### DIFF
--- a/WikiFunctions/ErrorHandler.cs
+++ b/WikiFunctions/ErrorHandler.cs
@@ -42,6 +42,7 @@ namespace WikiFunctions
         private static bool HandleKnownExceptions(Exception ex)
         {
             Tools.WriteDebug("HandleKnownExceptions", ex.StackTrace);
+            Exception exceptionOfInterest;
             // invalid regex - only ArgumentException, without subclasses
             if (ex is ArgumentException &&
                 (ex.StackTrace.Contains("System.Text.RegularExpressions") ||
@@ -58,10 +59,13 @@ namespace WikiFunctions
                     "Unsupported culture");
             }
             // network access error
-            else if (ex is System.Net.WebException || ex.InnerException is System.Net.WebException)
+            else if ((exceptionOfInterest = ex) is System.Net.WebException || 
+                (exceptionOfInterest = ex.InnerException) is System.Net.WebException)
             {
-                // if AWB starts up offline we'll hit here, so provide clear network related message
-                string msg = ex.Message.StartsWith(@"The type initializer for") ? ex.InnerException.Message : ex.Message;
+                string msg = exceptionOfInterest.Message;
+
+                if (exceptionOfInterest.HResult != 0)
+                    msg += string.Format(" (HRESULT 0x{0:X})", exceptionOfInterest.HResult);
 
                 MessageBox.Show(msg, "Network access error",
                     MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
The exact reason is unclear without it
for e.g. 'The request was aborted:
Could not create SSL/TLS secure channel.'

This is the last one for now.

Regarding how to move it to SVN: I guess you can "squash and merge", then copy the resulting commit into the SVN repo.